### PR TITLE
Disable shallow clone for installers-pr-* temporarily

### DIFF
--- a/.gocd/build.gocd.groovy
+++ b/.gocd/build.gocd.groovy
@@ -135,7 +135,9 @@ GoCD.script {
           template = 'installers-gradle'
 
           materials {
-            add(ctx.repo)
+            add((ctx.repo as GitMaterial).dup({
+              shallowClone = false
+            }))
 
             dependency('go-plugins') {
               pipeline = "plugins-${ctx.branchSanitized}"


### PR DESCRIPTION
https://build.gocd.org/go/tab/build/detail/installers-pull_8311/2/dist/1/dist has been failing for a git command with `fatal: ambiguous argument '20.7.0..f13c1bbeb9277773736adb2449ff5fb0977c3afb': unknown revision or path not in the working tree.` Disabling shallow clone to see if 20.7.0 will be available then